### PR TITLE
docs: add comprehensive worlddriven concept documentation

### DIFF
--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -1,0 +1,240 @@
+# Real-World Examples: How Worlddriven Would Solve Governance Crises
+
+This document examines actual governance failures in open source projects and demonstrates how worlddriven's democratic model would have prevented or resolved these crises.
+
+## Maintainer Burnout and Project Abandonment
+
+### Case Study: Redis Founder's Departure
+
+**The Crisis**: In June 2020, Salvatore Sanfilippo, Redis founder and lead maintainer, announced his departure from the project he had led for over a decade.
+
+**His Words**: "I'm asked more and more to express myself less and to maintain the project more. And this is indeed exactly what Redis needs right now. But this is not what I want to do."
+
+**The Problem**:
+- Single point of failure in project leadership
+- Maintainer burnout from overwhelming responsibilities
+- Community dependency on one person's continued interest
+- Risk of project stagnation or abandonment
+
+**How Worlddriven Would Help**:
+- **Distributed maintenance burden** across all contributors proportional to their involvement
+- **Democratic decision-making** removes pressure on individual maintainer to make all choices
+- **Community ownership** means project continues regardless of any individual's involvement
+- **Reduced emotional burden** as maintainer becomes facilitator, not sole decision-maker
+- **Sustainable participation** model that doesn't depend on individual heroics
+
+**The Outcome**: Redis survived due to corporate backing, but most projects lack this safety net.
+
+### Case Study: The Ignored Patch Problem
+
+**The Crisis**: Research reveals systematic failure where valuable contributions get ignored, leading to contributor abandonment.
+
+**The Pattern**:
+- Contributor submits well-crafted patch
+- Maintainer doesn't respond (too busy, on vacation, burned out)
+- Contributor pings once, twice, then gives up
+- Valuable improvement is lost
+- Contributor doesn't contribute again
+
+**Documented Examples**:
+- Studies show "wastelands of good patches that were completely ignored"
+- Contributors report submitting patches to multiple projects with no response
+- First-time contributors frequently abandon participation after being ignored
+
+**How Worlddriven Would Help**:
+- **Automatic processing** ensures every contribution gets consideration
+- **Time-based merging** means good patches don't languish indefinitely
+- **Community review** distributes evaluation burden beyond single maintainer
+- **Democratic blocking** allows community to prevent problematic merges
+- **Transparent timeline** shows contributors exactly when their work will be considered
+
+**The Impact**: Dramatically increased contributor retention and participation.
+
+## Corporate Takeovers and License Changes
+
+### Case Study: MongoDB's SSPL License Change
+
+**The Crisis**: In 2018, MongoDB changed from AGPL to the more restrictive Server Side Public License (SSPL) to prevent cloud vendors from offering MongoDB-as-a-service without contributing back.
+
+**The Problem**:
+- **Unilateral decision** by corporate entity controlling the project
+- **Community had no voice** in license change affecting their contributions
+- **Uncertainty for users** about future license stability
+- **Precedent set** for other corporate-controlled projects
+
+**Community Reaction**:
+- Confusion about implications for existing users
+- Concerns about future commercial restrictions
+- Some users began evaluating alternatives
+- Contributors questioned their future involvement
+
+**How Worlddriven Would Help**:
+- **Community vote** required for major changes like license modifications
+- **Contributor consensus** needed before implementation
+- **Transparent discussion** of alternatives and implications
+- **Democratic legitimacy** for decisions affecting all contributors
+- **Protection from unilateral corporate decisions**
+
+**The Result**: License changes would require genuine community support, preventing corporate capture of community projects.
+
+### Case Study: Docker Governance Tensions
+
+**The Crisis**: Docker Inc. maintained control over the Docker project while building commercial products around it, creating tensions between community and corporate interests.
+
+**The Problem**:
+- **Unclear boundaries** between open source project and commercial product
+- **Community contributions** potentially benefiting corporate interests disproportionately
+- **Governance confusion** about who makes final decisions
+- **Contributor concerns** about working for free to benefit corporate entity
+
+**How Worlddriven Would Help**:
+- **Clear democratic control** by contributors, not corporate entity
+- **Transparent decision-making** about project direction
+- **Community ownership** of project outcomes
+- **Corporate participation** as contributor, not controller
+- **Democratic oversight** of any commercial relationships
+
+## Project Forks and Community Splits
+
+### Case Study: GCC/EGCS Split and Reunification
+
+**The Crisis**: In the 1990s, disagreements between GCC's official maintainers and Cygnus Software (major contributor group) led to the creation of EGCS (Enhanced GNU Compiler Collection) as a competing fork.
+
+**The Progression**:
+1. **Technical disagreements** about development pace and feature inclusion
+2. **Maintainer conflicts** over project direction
+3. **Community split** with some supporting GCC, others EGCS
+4. **Resource duplication** as both projects developed in parallel
+5. **Market confusion** as distributors chose between compilers
+6. **Resolution** when EGCS gained wider adoption and was renamed back to GCC
+
+**How Worlddriven Would Have Helped**:
+- **Democratic voting** would have resolved direction disputes without forking
+- **Contribution-weighted influence** would have given Cygnus voice proportional to their work
+- **Transparent process** would have prevented behind-the-scenes conflicts
+- **Community consensus** would have emerged naturally through voting
+- **Resource focus** would have prevented duplicated effort
+
+**The Success**: The eventual reunification proved democratic choice works—EGCS won through community adoption. Worlddriven would have achieved this result without the wasteful fork period.
+
+### Case Study: GNU Emacs/XEmacs Division
+
+**The Crisis**: Conflicts between Richard Stallman's Free Software Foundation and Lucid, Inc. over GNU Emacs direction led to the XEmacs fork that persisted for decades.
+
+**The Problem**:
+- **Philosophical disagreements** about project direction
+- **Technical disputes** about feature inclusion
+- **Personal conflicts** between key developers
+- **Community fragmentation** lasting over 20 years
+- **Duplicated effort** on essentially similar projects
+
+**The Waste**:
+- Two development teams working on similar goals
+- Community split between competing implementations
+- User confusion about which version to choose
+- Features developed separately instead of collaboratively
+
+**How Worlddriven Would Have Helped**:
+- **Democratic resolution** of technical disputes through contributor voting
+- **Conflict mediation** through transparent, fair process
+- **Community decision-making** rather than individual authority
+- **Focus on code quality** rather than politics
+- **Unified development** based on collective contributor judgment
+
+## Small Contributor Marginalization
+
+### Case Study: Systematic Exclusion Patterns
+
+**The Problem**: Research documents patterns where small contributors face barriers to meaningful participation:
+
+**Barriers Identified**:
+- Pull requests ignored for weeks or months
+- No feedback provided on rejected contributions
+- High-friction review processes for minor improvements
+- Informal "insider" knowledge required for participation
+- Maintainer preferences override contributor efforts
+
+**Real Examples**:
+- Documentation improvements rejected for style reasons not documented anywhere
+- Bug fixes ignored because they don't align with unstated roadmap priorities
+- New contributor suggestions dismissed without explanation
+- Feature requests closed without discussion
+
+**How Worlddriven Changes This**:
+- **Every contribution matters** because contributors become voters
+- **Transparent evaluation** through public review process
+- **Democratic consideration** of all improvements
+- **Time-bound decisions** prevent indefinite delays
+- **Community ownership** of quality standards
+
+**The Impact**: Small contributors become stakeholders rather than supplicants.
+
+## Successful Democratic Resolutions
+
+### Case Study: Linux Kernel's Distributed Development
+
+**What Works**: The Linux kernel successfully manages thousands of contributors through hierarchical but democratic processes:
+
+- **Maintainer hierarchy** with clear responsibilities
+- **Contribution-based authority** where expertise determines influence
+- **Transparent processes** for patch submission and review
+- **Democratic consensus** for major decisions
+- **Distributed ownership** preventing single points of failure
+
+**Worlddriven Enhancement**: Worlddriven would formalize and automate these successful democratic principles while removing dependencies on individual maintainer availability.
+
+### Case Study: Apache Software Foundation Model
+
+**What Works**: Apache projects use democratic governance:
+
+- **Merit-based advancement** from contributor to committer to PMC member
+- **Voting requirements** for major decisions
+- **Transparent processes** documented in project bylaws
+- **Community ownership** through foundation structure
+- **Conflict resolution** through established procedures
+
+**Worlddriven Enhancement**: Worlddriven would automate merit recognition and voting, making participation more fluid and responsive.
+
+## The Pattern: Democracy Works
+
+### Common Success Factors
+1. **Contribution determines influence** rather than arbitrary authority
+2. **Transparent processes** prevent hidden agendas
+3. **Community ownership** creates investment in outcomes
+4. **Conflict resolution** through fair, open procedures
+5. **Distributed responsibility** prevents single points of failure
+
+### Common Failure Factors
+1. **Concentrated authority** in individuals or corporations
+2. **Opaque decision-making** processes
+3. **Exclusion of contributor voices** from important decisions
+4. **Arbitrary or inconsistent** standards and processes
+5. **Single points of failure** in leadership or infrastructure
+
+## Lessons for Future Projects
+
+### For Project Creators
+- **Plan for your own departure** from the beginning
+- **Build democratic processes** rather than depending on benevolent dictatorship
+- **Create transparent systems** that work without your constant involvement
+- **Empower contributors** to become stakeholders, not just suppliers
+
+### For Contributors
+- **Choose projects with democratic governance** for sustainable participation
+- **Understand your responsibility** when you gain influence
+- **Participate in project governance** as well as code contribution
+- **Support transparent, accountable decision-making**
+
+### For the Ecosystem
+- **Governance is a feature** as important as technical capabilities
+- **Democratic projects are more sustainable** than autocratic ones
+- **Community ownership** creates better long-term outcomes
+- **Transparency prevents most conflicts** before they become crises
+
+## Conclusion: Learning from History
+
+Every governance crisis in open source history demonstrates the same fundamental problem: concentration of power without accountability leads to community fragmentation, contributor burnout, and project instability.
+
+Worlddriven solves this by distributing both power and responsibility among those who actually build the software. It's not a theoretical improvement—it's a practical solution to documented, recurring problems in open source governance.
+
+**The choice is simple**: continue repeating the same governance failures, or adopt democratic principles that have already proven successful in the most important open source projects.

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,664 @@
+                    GNU AFFERO GENERAL PUBLIC LICENSE
+                       Version 3, 19 November 2007
+
+ Copyright (C) 2007 Free Software Foundation, Inc. <https://fsf.org/>
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+                            Preamble
+
+  The GNU Affero General Public License is a free, copyleft license for
+software and other kinds of works, specifically designed to ensure
+cooperation with the community in the case of network server software.
+
+  The licenses for most software and other practical works are designed
+to take away your freedom to share and change the works.  By contrast,
+our General Public Licenses are intended to guarantee your freedom to
+share and change all versions of a program--to make sure it remains free
+software for all its users.
+
+  When we speak of free software, we are referring to freedom, not
+price.  Our General Public Licenses are designed to make sure that you
+have the freedom to distribute copies of free software (and charge for
+them if you wish), that you receive source code or can get it if you
+want it, that you can change the software or use pieces of it in new
+free programs, and that you know you can do these things.
+
+  Developers that use our General Public Licenses protect your rights
+with two steps: (1) assert copyright on the software, and (2) offer
+you this License which gives you legal permission to copy, distribute
+and/or modify the software.
+
+  A secondary benefit of defending all users' freedom is that
+improvements made in alternate versions of the program, if they
+receive widespread use, become available for other developers to
+incorporate.  Many developers of free software are heartened and
+encouraged by the resulting cooperation.  However, in the case of
+software used on network servers, this result may fail to come about.
+The GNU General Public License permits making a modified version and
+letting the public access it on a server without ever releasing its
+source code to the public.
+
+  The GNU Affero General Public License is designed specifically to
+ensure that, in such cases, the modified source code becomes available
+to the community.  It requires the operator of a network server to
+provide the source code of the modified version running there to the
+users of that server.  Therefore, public use of a modified version, on
+a publicly accessible server, gives the public access to the source
+code of the modified version.
+
+  An older license, called the Affero General Public License and
+published by Affero, was designed to accomplish similar goals.  This is
+a different license, not a version of the Affero GPL, but Affero has
+released a new version of the Affero GPL which permits relicensing under
+this license.
+
+  The precise terms and conditions for copying, distribution and
+modification follow.
+
+                       TERMS AND CONDITIONS
+
+  0. Definitions.
+
+  "This License" refers to version 3 of the GNU Affero General Public License.
+
+  "Copyright" also means copyright-like laws that apply to other kinds of
+works, such as semiconductor masks.
+
+  "The Program" refers to any copyrightable work licensed under this
+License.  Each licensee is addressed as "you".  "Licensees" and
+"recipients" may be individuals or organizations.
+
+  To "modify" a work means to copy from or adapt all or part of the work
+in a fashion requiring copyright permission, other than the making of an
+exact copy.  The resulting work is called a "modified version" of the
+earlier work or a work "based on" the earlier work.
+
+  A "covered work" means either the unmodified Program or a work based
+on the Program.
+
+  To "propagate" a work means to do anything with it that, without
+permission, would make you directly or secondarily liable for
+infringement under applicable copyright law, except executing it on a
+computer or modifying a private copy.  Propagation includes copying,
+distribution (with or without modification), making available to the
+public, and in some countries other activities as well.
+
+  To "convey" a work means any kind of propagation that enables other
+parties to make or receive copies.  Mere interaction with a user through
+a computer network, with no transfer of a copy, is not conveying.
+
+  An interactive user interface displays "Appropriate Legal Notices"
+to the extent that it includes a convenient and prominently visible
+feature that (1) displays an appropriate copyright notice, and (2)
+tells the user that there is no warranty for the work (except to the
+extent that warranties are provided), that licensees may convey the
+work under this License, and how to view a copy of this License.  If
+the interface presents a list of user commands or options, such as a
+menu, a prominent item in the list meets this criterion.
+
+  1. Source Code.
+
+  The "source code" for a work means the preferred form of the work
+for making modifications to it.  "Object code" means any non-source
+form of a work.
+
+  A "Standard Interface" means an interface that either is an official
+standard defined by a recognized standards body, or, in the case of
+interfaces specified for a particular programming language, one that
+is widely used among developers working in that language.
+
+  The "System Libraries" of an executable work include anything, other
+than the work as a whole, that (a) is included in the normal form of
+packaging a Major Component, but which is not part of that Major
+Component, and (b) serves only to enable use of the work with that
+Major Component, or to implement a Standard Interface for which an
+implementation is available to the public in source code form.  A
+"Major Component", in this context, means a major essential component
+(kernel, window system, and so on) of the specific operating system
+(if any) on which the executable work runs, or a compiler used to
+produce the work, or an object code interpreter used to run it.
+
+  The "Corresponding Source" for a work in object code form means all
+the source code needed to generate, install, and (for an executable
+work) run the object code and to modify the work, including scripts to
+control those activities.  However, it does not include the work's
+System Libraries, or general-purpose tools or generally available free
+programs which are used unmodified in performing those activities but
+which are not part of the work.  For example, Corresponding Source
+includes interface definition files associated with source files for
+the work, and the source code for shared libraries and dynamically
+linked subprograms that the work is specifically designed to require,
+such as by intimate data communication or control flow between those
+subprograms and other parts of the work.
+
+  The Corresponding Source need not include anything that users
+can regenerate automatically from other parts of the Corresponding
+Source.
+
+  The Corresponding Source for a work in source code form is that
+same work.
+
+  2. Basic Permissions.
+
+  All rights granted under this License are granted for the term of
+copyright on the Program, and are irrevocable provided the stated
+conditions are met.  This License explicitly affirms your unlimited
+permission to run the unmodified Program.  The output from running a
+covered work is covered by this License only if the output, given its
+content, constitutes a covered work.  This License acknowledges your
+rights of fair use or other equivalent, as provided by copyright law.
+
+  You may make, run and propagate covered works that you do not
+convey, without conditions so long as your license otherwise remains
+in force.  You may convey covered works to others for the sole purpose
+of having them make modifications exclusively for you, or provide you
+with facilities for running those works, provided that you comply with
+the terms of this License in conveying all material for which you do
+not control copyright.  Those thus making or running the covered works
+for you must do so exclusively on your behalf, under your direction
+and control, on terms that prohibit them from making any copies of
+your copyrighted material outside their relationship with you.
+
+  Conveying under any other circumstances is permitted solely under
+the conditions stated below.  Sublicensing is not allowed; section 10
+makes it unnecessary.
+
+  3. Protecting Users' Legal Rights From Anti-Circumvention Law.
+
+  No covered work shall be deemed part of an effective technological
+measure under any applicable law fulfilling obligations under article
+11 of the WIPO copyright treaty adopted on 20 December 1996, or
+similar laws prohibiting or restricting circumvention of such
+measures.
+
+  When you convey a covered work, you waive any legal power to forbid
+circumvention of technological measures to the extent such circumvention
+is effected by exercising rights under this License with respect to
+the covered work, and you disclaim any intention to limit operation or
+modification of the work as a means of enforcing, against the work's
+users, your or third parties' legal rights to forbid circumvention of
+technological measures.
+
+  4. Conveying Verbatim Copies.
+
+  You may convey verbatim copies of the Program's source code as you
+receive it, in any medium, provided that you conspicuously and
+appropriately publish on each copy an appropriate copyright notice;
+keep intact all notices stating that this License and any
+non-permissive terms added in accord with section 7 apply to the code;
+keep intact all notices of the absence of any warranty; and give all
+recipients a copy of this License along with the Program.
+
+  You may charge any price or no price for each copy that you convey,
+and you may offer support or warranty protection for a fee.
+
+  5. Conveying Modified Source Versions.
+
+  You may convey a work based on the Program, or the modifications to
+produce it from the Program, in the form of source code under the
+terms of section 4, provided that you also meet all of these conditions:
+
+    a) The work must carry prominent notices stating that you modified
+    it, and giving a relevant date.
+
+    b) The work must carry prominent notices stating that it is
+    released under this License and any conditions added under section
+    7.  This requirement modifies the requirement in section 4 to
+    "keep intact all notices".
+
+    c) You must license the entire work, as a whole, under this
+    License to anyone who comes into possession of a copy.  This
+    License will therefore apply, along with any applicable section 7
+    additional terms, to the whole of the work, and all its parts,
+    regardless of how they are packaged.  This License gives no
+    permission to license the work in any other way, but it does not
+    invalidate such permission if you have separately received it.
+
+    d) If the work has interactive user interfaces, each must display
+    Appropriate Legal Notices; however, if the Program has interactive
+    interfaces that do not display Appropriate Legal Notices, your
+    work need not make them do so.
+
+  A compilation of a covered work with other separate and independent
+works, which are not by their nature extensions of the covered work,
+and which are not combined with it such as to form a larger program,
+in or on a volume of a storage or distribution medium, is called an
+"aggregate" if the compilation and its resulting copyright are not
+used to limit the access or legal rights of the compilation's users
+beyond what the individual works permit.  Inclusion of a covered work
+in an aggregate does not cause this License to apply to the other
+parts of the aggregate.
+
+  6. Conveying Non-Source Forms.
+
+  You may convey a covered work in object code form under the terms
+of sections 4 and 5, provided that you also convey the
+machine-readable Corresponding Source under the terms of this License,
+in one of these ways:
+
+    a) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by the
+    Corresponding Source fixed on a durable physical medium
+    customarily used for software interchange.
+
+    b) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by a
+    written offer, valid for at least three years and valid for as
+    long as you offer spare parts or customer support for that product
+    model, to give anyone who possesses the object code either (1) a
+    copy of the Corresponding Source for all the software in the
+    product that is covered by this License, on a durable physical
+    medium customarily used for software interchange, for a price no
+    more than your reasonable cost of physically performing this
+    conveying of source, or (2) access to copy the
+    Corresponding Source from a network server at no charge.
+
+    c) Convey individual copies of the object code with a copy of the
+    written offer to provide the Corresponding Source.  This
+    alternative is allowed only occasionally and noncommercially, and
+    only if you received the object code with such an offer, in accord
+    with subsection 6b.
+
+    d) Convey the object code by offering access from a designated
+    place (gratis or for a charge), and offer equivalent access to the
+    Corresponding Source in the same way through the same place at no
+    further charge.  You need not require recipients to copy the
+    Corresponding Source along with the object code.  If the place to
+    copy the object code is a network server, the Corresponding Source
+    may be on a different server (operated by you or a third party)
+    that supports equivalent copying facilities, provided you maintain
+    clear directions next to the object code saying where to find the
+    Corresponding Source.  Regardless of what server hosts the
+    Corresponding Source, you remain obligated to ensure that it is
+    available for as long as needed to satisfy these requirements.
+
+    e) Convey the object code using peer-to-peer transmission, provided
+    you inform other peers where the object code and Corresponding
+    Source of the work are being offered to the general public at no
+    charge under subsection 6d.
+
+  A separable portion of the object code, whose source code is excluded
+from the Corresponding Source as a System Library, need not be
+included in conveying the object code work.
+
+  A "User Product" is either (1) a "consumer product", which means any
+tangible personal property which is normally used for personal, family,
+or household purposes, or (2) anything designed or sold for incorporation
+into a dwelling.  In determining whether a product is a consumer product,
+doubtful cases shall be resolved in favor of coverage.  For a particular
+product received by a particular user, "normally used" refers to a
+typical or common use of that class of product, regardless of the status
+of the particular user or of the way in which the particular user
+actually uses, or expects or is expected to use, the product.  A product
+is a consumer product regardless of whether the product has substantial
+commercial, industrial or non-consumer uses, unless such uses represent
+the only significant mode of use of the product.
+
+  "Installation Information" for a User Product means any methods,
+procedures, authorization keys, or other information required to install
+and execute modified versions of a covered work in that User Product from
+a modified version of its Corresponding Source.  The information must
+suffice to ensure that the continued functioning of the modified object
+code is in no case prevented or interfered with solely because
+modification has been made.
+
+  If you convey an object code work under this section in, or with, or
+specifically for use in, a User Product, and the conveying occurs as
+part of a transaction in which the right of possession and use of the
+User Product is transferred to the recipient in perpetuity or for a
+fixed term (regardless of how the transaction is characterized), the
+Corresponding Source conveyed under this section must be accompanied
+by the Installation Information.  But this requirement does not apply
+if neither you nor any third party retains the ability to install
+modified object code on the User Product (for example, the work has
+been installed in ROM).
+
+  The requirement to provide Installation Information does not include a
+requirement to continue to provide support service, warranty, or updates
+for a work that has been modified or installed by the recipient, or for
+the User Product in which it has been modified or installed.  Access to a
+network may be denied when the modification itself materially and
+adversely affects the operation of the network or violates the rules and
+protocols for communication across the network.
+
+  Corresponding Source conveyed, and Installation Information provided,
+in accord with this section must be in a format that is publicly
+documented (and with an implementation available to the public in
+source code form), and must require no special password or key for
+unpacking, reading or copying.
+
+  7. Additional Terms.
+
+  "Additional permissions" are terms that supplement the terms of this
+License by making exceptions from one or more of its conditions.
+Additional permissions that are applicable to the entire Program shall
+be treated as though they were included in this License, to the extent
+that they are valid under applicable law.  If additional permissions
+apply only to part of the Program, that part may be used separately
+under those permissions, but the entire Program remains governed by
+this License without regard to the additional permissions.
+
+  When you convey a copy of a covered work, you may at your option
+remove any additional permissions from that copy, or from any part of
+it.  (Additional permissions may be written to require their own
+removal in certain cases when you modify the work.)  You may place
+additional permissions on material, added by you to a covered work,
+for which you have or can give appropriate copyright permission.
+
+  Notwithstanding any other provision of this License, for material you
+add to a covered work, you may (if authorized by the copyright holders of
+that material) supplement the terms of this License with terms:
+
+    a) Disclaiming warranty or limiting liability differently from the
+    terms of sections 15 and 16 of this License; or
+
+    b) Requiring preservation of specified reasonable legal notices or
+    author attributions in that material or in the Appropriate Legal
+    Notices displayed by works containing it; or
+
+    c) Prohibiting misrepresentation of the origin of that material, or
+    requiring that modified versions of such material be marked in
+    reasonable ways as different from the original version; or
+
+    d) Limiting the use for publicity purposes of names of licensors or
+    authors of the material; or
+
+    e) Declining to grant rights under trademark law for use of some
+    trade names, trademarks, or service marks; or
+
+    f) Requiring indemnification of licensors and authors of that
+    material by anyone who conveys the material (or modified versions of
+    it) with contractual assumptions of liability to the recipient, for
+    any liability that these contractual assumptions directly impose on
+    those licensors and authors.
+
+  All other non-permissive additional terms are considered "further
+restrictions" within the meaning of section 10.  If the Program as you
+received it, or any part of it, contains a notice stating that it is
+governed by this License along with a term that is a further
+restriction, you may remove that term.  If a license document contains
+a further restriction but permits relicensing or conveying under this
+License, you may add to a covered work material governed by the terms
+of that license document, provided that the further restriction does
+not survive such relicensing or conveying.
+
+  If you add terms to a covered work in accord with this section, you
+must place, in the relevant source files, a statement of the
+additional terms that apply to those files, or a notice indicating
+where to find the applicable terms.
+
+  Additional terms, permissive or non-permissive, may be stated in the
+form of a separately written license, or stated as exceptions;
+the above requirements apply either way.
+
+  8. Termination.
+
+  You may not propagate or modify a covered work except as expressly
+provided under this License.  Any attempt otherwise to propagate or
+modify it is void, and will automatically terminate your rights under
+this License (including any patent licenses granted under the third
+paragraph of section 11).
+
+  However, if you cease all violation of this License, then your
+license from a particular copyright holder is reinstated (a)
+provisionally, unless and until the copyright holder explicitly and
+finally terminates your license, and (b) permanently, if the copyright
+holder fails to notify you of the violation by some reasonable means
+prior to 60 days after the cessation.
+
+  Moreover, your license from a particular copyright holder is
+reinstated permanently if the copyright holder notifies you of the
+violation by some reasonable means, this is the first time you have
+received notice of violation of this License (for any work) from that
+copyright holder, and you cure the violation prior to 30 days after
+your receipt of the notice.
+
+  Termination of your rights under this section does not terminate the
+licenses of parties who have received copies or rights from you under
+this License.  If your rights have been terminated and not permanently
+reinstated, you do not qualify to receive new licenses for the same
+material under section 10.
+
+  9. Acceptance Not Required for Having Copies.
+
+  You are not required to accept this License in order to receive or
+run a copy of the Program.  Ancillary propagation of a covered work
+occurring solely as a consequence of using peer-to-peer transmission
+to receive a copy likewise does not require acceptance.  However,
+nothing other than this License grants you permission to propagate or
+modify any covered work.  These actions infringe copyright if you do
+not accept this License.  Therefore, by modifying or propagating a
+covered work, you indicate your acceptance of this License to do so.
+
+  10. Automatic Licensing of Downstream Recipients.
+
+  Each time you convey a covered work, the recipient automatically
+receives a license from the original licensors, to run, modify and
+propagate that work, subject to this License.  You are not responsible
+for enforcing compliance by third parties with this License.
+
+  An "entity transaction" is a transaction transferring control of an
+organization, or substantially all assets of one, or subdividing an
+organization, or merging organizations.  If propagation of a covered
+work results from an entity transaction, each party to that
+transaction who receives a copy of the work also receives whatever
+licenses to the work the party's predecessor in interest had or could
+give under the previous paragraph, plus a right to possession of the
+Corresponding Source of the work from the predecessor in interest, if
+the predecessor has it or can get it with reasonable efforts.
+
+  You may not impose any further restrictions on the exercise of the
+rights granted or affirmed under this License.  For example, you may
+not impose a license fee, royalty, or other charge for exercise of
+rights granted under this License, and you may not initiate litigation
+(including a cross-claim or counterclaim in a lawsuit) alleging that
+any patent claim is infringed by making, using, selling, offering for
+sale, or importing the Program or any portion of it.
+
+  11. Patents.
+
+  A "contributor" is a copyright holder who authorizes use under this
+License of the Program or a work on which the Program is based.  The
+work thus licensed is called the contributor's "contributor version".
+
+  A contributor's "essential patent claims" are all patent claims
+owned or controlled by the contributor, whether already acquired or
+hereafter acquired, that would be infringed by some manner, permitted
+by this License, of making, using, or selling its contributor version,
+but do not include claims that would be infringed only as a
+consequence of further modification of the contributor version.  For
+purposes of this definition, "control" includes the right to grant
+patent sublicenses in a manner consistent with the requirements of
+this License.
+
+  Each contributor grants you a non-exclusive, worldwide, royalty-free
+patent license under the contributor's essential patent claims, to
+make, use, sell, offer for sale, import and otherwise run, modify and
+propagate the contents of its contributor version.
+
+  In the following three paragraphs, a "patent license" is any express
+agreement or commitment, however denominated, not to enforce a patent
+(such as an express permission to practice a patent or covenant not to
+sue for patent infringement).  To "grant" such a patent license to a
+party means to make such an agreement or commitment not to enforce a
+patent against the party.
+
+  If you convey a covered work, knowingly relying on a patent license,
+and the Corresponding Source of the work is not available for anyone
+to copy, free of charge and under the terms of this License, through a
+publicly available network server or other readily accessible means,
+then you must either (1) cause the Corresponding Source to be so
+available, or (2) arrange to deprive yourself of the benefit of the
+patent license for this particular work, or (3) arrange, in a manner
+consistent with the requirements of this License, to extend the patent
+license to downstream recipients.  "Knowingly relying" means you have
+actual knowledge that, but for the patent license, your conveying the
+covered work in a country, or your recipient's use of the covered work
+in a country, would infringe one or more identifiable patents in that
+country that you have reason to believe are valid.
+
+  If, pursuant to or in connection with a single transaction or
+arrangement, you convey, or propagate by procuring conveyance of, a
+covered work, and grant a patent license to some of the parties
+receiving the covered work authorizing them to use, propagate, modify
+or convey a specific copy of the covered work, then the patent license
+you grant is automatically extended to all recipients of the covered
+work and works based on it.
+
+  A patent license is "discriminatory" if it does not include within
+the scope of its coverage, prohibits the exercise of, or is
+conditioned on the non-exercise of one or more of the rights that are
+specifically granted under this License.  You may not convey a covered
+work if you are a party to an arrangement with a third party that is
+in the business of distributing software, under which you make payment
+to the third party based on the extent of your activity of conveying
+the work, and under which the third party grants, to any of the
+parties who would receive the covered work from you, a discriminatory
+patent license (a) in connection with copies of the covered work
+conveyed by you (or copies made from those copies), or (b) primarily
+for and in connection with specific products or compilations that
+contain the covered work, unless you entered into that arrangement,
+or that patent license was granted, prior to 28 March 2007.
+
+  Nothing in this License shall be construed as excluding or limiting
+any implied license or other defenses to infringement that may
+otherwise be available to you under applicable patent law.
+
+  12. No Surrender of Others' Freedom.
+
+  If conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot convey a
+covered work so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you may
+not convey it at all.  For example, if you agree to terms that obligate you
+to collect a royalty for further conveying from those to whom you convey
+the Program, the only way you could satisfy both those terms and this
+License would be to refrain entirely from conveying the Program.
+
+  13. Remote Network Interaction; Use with the GNU General Public License.
+
+  Notwithstanding any other provision of this License, if you modify the
+Program, your modified version must prominently offer all users
+interacting with it remotely through a computer network (if your version
+supports such interaction) an opportunity to receive the Corresponding
+Source of your version by providing access to the Corresponding Source
+from a network server at no charge, through some standard or customary
+means of facilitating copying of software.  This Corresponding Source
+shall include the Corresponding Source for any work covered by version 3
+of the GNU General Public License that is incorporated pursuant to the
+following paragraph.
+
+  Notwithstanding any other provision of this License, you have
+permission to link or combine any covered work with a work licensed
+under version 3 of the GNU General Public License into a single
+combined work, and to convey the resulting work.  The terms of this
+License will continue to apply to the part which is the covered work,
+but the work with which it is combined will remain governed by version
+3 of the GNU General Public License.
+
+  14. Revised Versions of this License.
+
+  The Free Software Foundation may publish revised and/or new versions of
+the GNU Affero General Public License from time to time.  Such new versions
+will be similar in spirit to the present version, but may differ in detail to
+address new problems or concerns.
+
+  Each version is given a distinguishing version number.  If the
+Program specifies that a certain numbered version of the GNU Affero General
+Public License "or any later version" applies to it, you have the
+option of following the terms and conditions either of that numbered
+version or of any later version published by the Free Software
+Foundation.  If the Program does not specify a version number of the
+GNU Affero General Public License, you may choose any version ever published
+by the Free Software Foundation.
+
+  If the Program specifies that a proxy can decide which future
+versions of the GNU Affero General Public License can be used, that proxy's
+public statement of acceptance of a version permanently authorizes you
+to choose that version for the Program.
+
+  Later license versions may give you additional or different
+permissions.  However, no additional obligations are imposed on any
+author or copyright holder as a result of your choosing to follow a
+later version.
+
+  15. Disclaimer of Warranty.
+
+  THERE IS NO WARRANTY FOR THE PROGRAM, TO THE EXTENT PERMITTED BY
+APPLICABLE LAW.  EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT
+HOLDERS AND/OR OTHER PARTIES PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY
+OF ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO,
+THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE.  THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE PROGRAM
+IS WITH YOU.  SHOULD THE PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF
+ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
+
+  16. Limitation of Liability.
+
+  IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MODIFIES AND/OR CONVEYS
+THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES, INCLUDING ANY
+GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF THE
+USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED TO LOSS OF
+DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD
+PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER PROGRAMS),
+EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF
+SUCH DAMAGES.
+
+  17. Interpretation of Sections 15 and 16.
+
+  If the disclaimer of warranty and limitation of liability provided
+above cannot be given local legal effect according to their terms,
+reviewing courts shall apply local law that most closely approximates
+an absolute waiver of all civil liability in connection with the
+Program, unless a warranty or assumption of liability accompanies a
+copy of the Program in return for a fee.
+
+                     END OF TERMS AND CONDITIONS
+
+            How to Apply These Terms to Your New Programs
+
+  If you develop a new program, and you want it to be of the greatest
+possible use to the public, the best way to achieve this is to make it
+free software which everyone can redistribute and change under these terms.
+
+  To do so, attach the following notices to the program.  It is safest
+to attach them to the start of each source file to most effectively
+state the exclusion of warranty; and each file should have at least
+the "copyright" line and a pointer to where the full notice is found.
+
+    <one line to give the program's name and a brief idea of what it does.>
+    Copyright (C) <year>  <name of author>
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as published
+    by the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+Also add information on how to contact you by electronic and paper mail.
+
+  If your software can interact with users remotely through a computer
+network, you should also make sure that it provides a way for users to
+get its source.  For example, if your program is a web application, its
+interface could display a "Source" link that leads users to an archive
+of the code.  There are many ways you could offer source, and different
+solutions will be better for different programs; see section 13 for the
+specific requirements.
+
+  You should also get your employer (if you work as a programmer) or school,
+if any, to sign a "copyright disclaimer" for the program, if necessary.
+For more information on this, and how to apply and follow the GNU AGPL, see
+<https://www.gnu.org/licenses/>.
+
+  "featured": false
+}

--- a/PHILOSOPHY.md
+++ b/PHILOSOPHY.md
@@ -1,0 +1,238 @@
+# Philosophy: Democratic Software Development
+
+Worlddriven represents a fundamental shift in how we think about software development governance. It applies democratic principles to code collaboration, creating systems that are more transparent, accountable, and sustainable than traditional maintainer-centric models.
+
+## Core Philosophical Principles
+
+### 1. Those Who Build Should Govern
+
+The fundamental principle of worlddriven is simple: the people who do the work should make the decisions. This isn't just practical—it's morally correct.
+
+**Traditional Model**: Maintainers control projects while contributors supply labor
+**Democratic Model**: Contributors collectively control the projects they build
+
+This aligns power with responsibility and investment, creating natural incentives for good decision-making.
+
+### 2. Meritocracy Through Contribution
+
+True meritocracy isn't about credentials, connections, or corporate backing—it's about demonstrated contribution to the shared work.
+
+**Contribution-Weighted Democracy**:
+- Your influence scales with your investment in the project
+- Historical contributors maintain earned authority
+- New contributors can quickly gain influence through quality work
+- No artificial barriers prevent merit-based advancement
+
+This creates a fluid hierarchy based on actual value delivered rather than political positioning.
+
+### 3. Transparency as Foundation
+
+Democracy requires informed participation. Worlddriven makes all governance processes transparent and auditable.
+
+**Transparent Elements**:
+- Contribution history determines voting weight
+- All votes and reviews are public
+- Decision algorithms are open source
+- Influence calculations are verifiable
+- Process changes require community approval
+
+Without transparency, democracy becomes theater. With it, democracy becomes accountable.
+
+### 4. Collective Responsibility
+
+Power without responsibility leads to poor decisions. Worlddriven links voting power directly to project ownership and accountability.
+
+**Responsibility Framework**:
+- Contributors own the outcomes of their votes
+- Quality affects something they help control
+- Long-term sustainability becomes everyone's concern
+- Community standards are collectively maintained
+
+This creates investment mentality rather than consumer mentality.
+
+## Democratic Theory Applied to Software
+
+### Direct Democracy for Code
+
+Traditional representative democracy makes sense for large-scale governance where direct participation is impractical. Software projects can implement direct democracy because:
+
+**Scale is Manageable**: Most projects have dozens to hundreds of active contributors, not millions of citizens
+
+**Issue Specificity**: Votes focus on specific technical changes rather than broad policy directions
+
+**Expertise Relevance**: Contributors have direct technical knowledge of what they're voting on
+
+**Continuous Participation**: Contributors remain engaged with ongoing project evolution
+
+### Weighted Voting Systems
+
+Pure one-person-one-vote democracy doesn't account for different levels of investment and expertise. Worlddriven uses contribution-weighted voting because:
+
+**Investment Alignment**: Those with more at stake get more influence over outcomes
+
+**Expertise Recognition**: Sustained contribution demonstrates competence and commitment
+
+**Sybil Attack Prevention**: Voting weight requires actual work, not just account creation
+
+**Natural Meritocracy**: Influence flows to those who prove value through contribution
+
+### Temporal Governance
+
+Unlike traditional elections with fixed terms, worlddriven implements continuous governance where:
+
+**Decisions Happen Continuously**: Every pull request is a small democratic decision
+
+**Influence Updates Dynamically**: Recent contributions affect current voting weight
+
+**Participation is Voluntary**: Contributors vote when they care about specific changes
+
+**Authority Flows Naturally**: Leadership emerges through sustained quality contribution
+
+## Philosophical Foundations
+
+### Social Contract Theory
+
+Worlddriven implements a social contract where:
+
+**Contributors Agree**: To submit their work to democratic evaluation
+
+**Community Commits**: To fair, transparent review processes
+
+**Everyone Benefits**: From collective wisdom and shared responsibility
+
+**Mutual Accountability**: Creates stability and trust
+
+This voluntary association creates legitimacy that top-down authority lacks.
+
+### Libertarian Principles
+
+Worlddriven respects individual autonomy while enabling collective action:
+
+**Voluntary Participation**: No one is forced to contribute or vote
+
+**Exit Rights**: Contributors can fork if they disagree with community direction
+
+**Minimal Coercion**: Decisions emerge from voluntary association, not imposed authority
+
+**Self-Organization**: Communities organize themselves through contribution patterns
+
+### Commons Governance
+
+Drawing from Elinor Ostrom's work on commons management, worlddriven implements proven principles for sustainable collective resource management:
+
+**Clearly Defined Boundaries**: Who can vote (contributors) and what they control (project direction)
+
+**Congruence**: Those affected by decisions have voice proportional to their involvement
+
+**Collective Choice**: Rules can be modified by those affected by them
+
+**Monitoring**: Transparent processes allow community oversight
+
+**Graduated Sanctions**: Poor contributions get downvoted, but contributors aren't expelled
+
+**Conflict Resolution**: Democratic voting provides fair mechanism for dispute resolution
+
+### Pragmatic Idealism
+
+Worlddriven balances idealistic vision with practical implementation:
+
+**Idealistic Vision**: Truly democratic software development that empowers all contributors
+
+**Practical Implementation**: Working system deployed today that solves real problems
+
+**Gradual Evolution**: Three-phase roadmap from current PR voting to future self-governing systems
+
+**Proven Principles**: Applies democratic theory that works in other contexts to software development
+
+## Addressing Common Criticisms
+
+### "Developers Aren't Politicians"
+
+**Criticism**: Software developers aren't trained in governance and should focus on code
+
+**Response**: Developers already make governance decisions (code review, architecture choices, community standards). Worlddriven makes these decisions transparent and accountable rather than arbitrary and opaque.
+
+**Evidence**: The most successful open source projects (Linux, Apache projects) already use democratic governance principles. Worlddriven formalizes what works.
+
+### "Majority Rule Oppresses Minorities"
+
+**Criticism**: Democratic voting allows majorities to override minority viewpoints
+
+**Response**: Contribution-weighted voting means technical minorities with expertise can outweigh uninformed majorities. Plus, fork rights provide ultimate minority protection.
+
+**Safeguards**: Historical contributors maintain influence, new ideas can gain support through demonstration, and technical merit affects contribution weight.
+
+### "This Will Slow Down Development"
+
+**Criticism**: Democratic processes are slower than benevolent dictatorship
+
+**Response**: Worlddriven actually accelerates development by removing maintainer bottlenecks. Automatic time-based merging ensures progress continues even when maintainers are unavailable.
+
+**Evidence**: Projects die from maintainer burnout more often than from too much democracy.
+
+### "Code Quality Will Suffer"
+
+**Criticism**: Democratic voting will allow poor code to be merged
+
+**Response**: Contributors who control the project have direct incentive to maintain quality. Poor code affects something they own and must maintain.
+
+**Safeguards**: Experienced contributors have more voting weight, change requests can block merges, and transparent review creates accountability.
+
+## Philosophical Implications
+
+### Democratizing Digital Infrastructure
+
+Software runs the world. Democratic governance of software development means democratic control of digital infrastructure. This has profound implications:
+
+**Political**: Software becomes accountable to users rather than corporate interests
+
+**Economic**: Value creation gets shared among those who build rather than concentrated among those who own
+
+**Social**: Technical communities become models for democratic organization
+
+**Cultural**: Collaboration replaces competition as the organizing principle
+
+### Beyond Software: Democratic Organization Models
+
+Worlddriven principles apply beyond software:
+
+**Research Collaboration**: Academic papers could use contribution-weighted review
+
+**Content Creation**: Wikis and documentation could implement democratic editing
+
+**Community Management**: Online communities could use participation-based governance
+
+**Resource Allocation**: Shared resources could be managed democratically by users
+
+### Evolutionary Pressure
+
+Worlddriven creates evolutionary pressure toward better governance:
+
+**Projects with Democratic Governance**: Attract more contributors, have better retention, and produce higher quality outcomes
+
+**Projects with Autocratic Governance**: Lose contributors to democratic alternatives, suffer from maintainer burnout, and stagnate over time
+
+**Market Forces**: Users and contributors naturally gravitate toward more responsive, accountable projects
+
+This creates positive feedback loops that spread democratic governance throughout the ecosystem.
+
+## The Vision: Software as Democratic Practice
+
+### Phase 1: Proof of Concept
+Current worlddriven deployment proves democratic software governance works at scale. Contributors participate enthusiastically when they have real influence over outcomes.
+
+### Phase 2: Infrastructure Democracy
+Extending democratic governance to infrastructure management creates transparency and accountability in how software systems operate, not just how they're developed.
+
+### Phase 3: Self-Governing Systems
+The ultimate vision: software systems that govern themselves through democratic contributor consensus, creating truly autonomous, accountable digital infrastructure.
+
+## Conclusion: Democracy as Default
+
+The question isn't whether democratic governance works for software development—the most successful projects already use democratic principles. The question is whether we'll formalize and extend these principles or continue depending on individual heroics and corporate benevolence.
+
+Worlddriven makes the democratic choice explicit and automatic. It turns the exception into the rule, the informal into the systematic, the fragile into the robust.
+
+**Democracy isn't just a political ideal—it's a practical tool for building better software with better communities.**
+
+The future of software development is democratic. Worlddriven makes that future available today.

--- a/README.md
+++ b/README.md
@@ -1,1 +1,145 @@
-# documentation
+# Worlddriven: Democratic Governance for Open Source
+
+**Worlddriven is democratic governance for open source software. It transforms code contributions into voting power, giving every contributor both the ability and responsibility to steer project direction. By replacing maintainer bottlenecks with community-driven decision making, worlddriven ensures projects remain alive, responsive, and truly collaborative.**
+
+## The Democracy Problem in Open Source
+
+Open source software powers the modern world, yet its governance remains fundamentally undemocratic. This creates critical vulnerabilities that threaten the sustainability and integrity of projects we all depend on.
+
+### Maintainer Bottlenecks
+- **58% of maintainers** have abandoned projects or considered doing so due to burnout
+- **22% have already left**, with 36% actively considering it
+- Over **three-quarters receive no financial compensation** for their work
+- Projects die when single maintainers become overwhelmed or move on
+
+### Ignored Contributors
+Research reveals a "wasteland of good patches that were completely ignored," where contributors:
+- Submit valuable improvements that receive no response
+- Ping maintainers multiple times before giving up
+- Abandon participation due to systematic neglect
+- Face barriers that prevent democratic participation in projects they care about
+
+### Corporate Takeovers
+- **MongoDB, Redis, and others** changed licenses to prevent corporate exploitation
+- **Docker governance tensions** between project and company interests
+- **Foundation vs. company-led models** create ongoing conflicts over control
+- License changes effectively privatize community work
+
+### Fork Wars
+Famous conflicts that split communities and waste resources:
+- **GCC/EGCS split** due to maintainer disagreements (eventually resolved)
+- **GNU Emacs/XEmacs** division over project direction
+- **BSD fragmentation** into FreeBSD, NetBSD, and OpenBSD
+- Personal conflicts creating unnecessary project duplication
+
+## What is Worlddriven?
+
+Worlddriven revolutionizes open source governance by implementing democratic decision-making that scales with contribution.
+
+### Power Through Participation
+Your first commit gives you a voice in the project's future. Continued contributions build your influence, creating a direct democracy where those who do the work make the decisions.
+
+### Shared Responsibility
+Contributors don't just submit code—they become stewards of the project's future. With voting power comes accountability for the project's direction, quality, and community health.
+
+### Time-based Auto-merge
+Pull requests automatically merge after a configurable time period (default: 10 days), but community votes can accelerate or block merges:
+- **Positive reviews** from contributors reduce merge time
+- **Change requests** increase merge time or block merging entirely
+- **Vote weight** is proportional to the reviewer's historical contributions
+- **Transparent calculations** show exactly how decisions are made
+
+### Eliminates Single Points of Failure
+No more projects dying because one maintainer burns out. The community collectively shoulders both the burden and benefits of project stewardship.
+
+## Real-World Examples Where Worlddriven Would Help
+
+### Redis Creator's Departure
+Salvatore Sanfilippo, Redis founder, stepped down in 2020 saying: "I'm asked more and more to express myself less and to maintain the project more. This is not what I want to do." Worlddriven would have distributed this maintenance burden across the contributor community.
+
+### The Ignored Patch Problem
+Many projects show systematic failures where good contributions are ignored, leading to contributor abandonment. Worlddriven's automatic merge system ensures every contribution gets proper consideration and resolution.
+
+### MongoDB License Controversy
+When MongoDB changed to SSPL to prevent cloud vendor exploitation, it created uncertainty for users. Worlddriven's democratic process would have allowed the community to collectively decide on license changes based on contributor consensus.
+
+### GCC/EGCS Success Story
+The GCC/EGCS fork eventually reunited when it became clear EGCS had better community support. Worlddriven's voting system would have revealed this preference earlier, preventing the fork entirely and focusing energy on collaborative improvement.
+
+## The Responsibility Model
+
+### Entry Level: First Contribution = First Vote = First Responsibility
+Making your first commit immediately grants voting rights and begins your stewardship role in the project's future. You're no longer just a user—you're an owner.
+
+### Growing Influence: More Contributions = Greater Stewardship
+Your voting power scales with your investment in the project. Long-term contributors naturally gain more influence, but newcomers can quickly earn significant voice through quality contributions.
+
+### Collective Ownership
+Everyone who contributes owns and is responsible for the outcome. This creates a culture of investment rather than extraction, where contributors think long-term because they control the project's destiny.
+
+### Democratic Leadership, Not Dictatorship
+Veteran contributors become democratic leaders who guide through influence and example, not absolute authority. Their expertise carries weight, but the community makes collective decisions.
+
+## How Worlddriven Changes the Game
+
+### From Spectator to Stakeholder
+Traditional open source asks you to submit patches and hope they're accepted. Worlddriven makes you an immediate stakeholder with both power and responsibility for project success.
+
+### Prevents Corporate Capture
+When the community collectively owns decision-making, no single entity can unilaterally change licenses, direction, or governance. Contributors who built the project retain democratic control.
+
+### Reduces Fork Necessity
+Disagreements get resolved through democratic process rather than community fragmentation. Energy focuses on collaborative improvement instead of competing implementations.
+
+### Sustainable Participation
+By distributing both power and responsibility, worlddriven creates sustainable participation models that don't depend on individual heroics or burnout-prone maintainership.
+
+## The Vision: Three Phases
+
+### Phase 1 (Current): Democratic Pull Request Merging
+- Solves immediate maintainer bottleneck problems
+- Proves democratic governance concept works at scale
+- Establishes contributor responsibility culture
+- Currently deployed at [www.worlddriven.org](https://www.worlddriven.org)
+
+### Phase 2: Transparent Service Management
+- Entire services managed via pull requests
+- Infrastructure as Code meets democracy
+- Community-driven operational decisions with shared accountability
+- Server configurations, deployments, and policies decided collectively
+
+### Phase 3: Self-Governing Software Ecosystem
+- Minimal human intervention required
+- Fully automated, transparent infrastructure
+- True digital democracy where contributors collectively own all outcomes
+- Software that governs itself through democratic contributor consensus
+
+## Why Now?
+
+### The Crisis is Real
+Open source faces a sustainability crisis with widespread maintainer burnout, corporate capture of community projects, and a democratic deficit in software that runs the world's infrastructure.
+
+### The Infrastructure Exists
+GitHub and GitLab provide the technical foundation. The challenge isn't technical—it's governance. Worlddriven solves the governance problem.
+
+### Community Readiness
+Growing awareness of open source governance problems creates demand for solutions. Contributors want meaningful participation, not just code submission privileges.
+
+### Proven Principles
+Democratic governance works in other contexts. Worlddriven adapts these principles for software development, creating accountability through transparency and shared ownership.
+
+## Get Started
+
+Visit [www.worlddriven.org](https://www.worlddriven.org) to enable worlddriven for your repositories. Join the growing movement toward democratic, transparent, and sustainable open source governance.
+
+**Ready to take responsibility for the software you help create?**
+
+---
+
+*Learn more about the principles behind worlddriven:*
+- [Responsibility Model](RESPONSIBILITY.md) - How contributor power and accountability scale together
+- [Real-World Examples](EXAMPLES.md) - Detailed case studies of governance failures worlddriven prevents
+- [Philosophy](PHILOSOPHY.md) - Democratic software development principles
+- [Vision](VISION.md) - The three-phase roadmap to self-governing software
+
+*Technical implementation details are available in the [core repository](../core/README.md).*

--- a/RESPONSIBILITY.md
+++ b/RESPONSIBILITY.md
@@ -1,0 +1,177 @@
+# The Responsibility Model: Power and Accountability in Worlddriven
+
+Worlddriven fundamentally changes the relationship between contributors and projects by linking power directly to responsibility. This creates a sustainable governance model where those who shape the code also shape the future.
+
+## Core Principle: Contribution = Ownership = Accountability
+
+Traditional open source treats contributors as external suppliers submitting patches to maintainer gatekeepers. Worlddriven transforms contributors into owners who collectively control project destiny.
+
+### The Transformation
+- **Before**: Submit code → Hope for acceptance → No ongoing influence
+- **After**: Submit code → Gain voting power → Share responsibility for outcomes
+
+This shift creates deep investment in project success because contributors control what they help build.
+
+## Scaling Responsibility with Influence
+
+### Entry Level: First Commit, First Vote, First Responsibility
+
+Making your first contribution immediately grants:
+- **Voting rights** on all future pull requests
+- **Influence weight** proportional to your single contribution
+- **Stewardship responsibility** for the project's future direction
+
+You're no longer an external contributor hoping for acceptance—you're a project owner with decision-making power and accountability for outcomes.
+
+### Building Influence Through Investment
+
+Each additional contribution increases your:
+- **Vote weight** in proportion to cumulative contributions
+- **Responsibility** for project direction and quality
+- **Stake** in long-term project success
+
+This creates natural incentives for thoughtful, high-quality contributions because poor decisions directly impact something you help control.
+
+### Veteran Leadership Through Democratic Means
+
+Long-term contributors gain substantial influence but cannot exercise dictatorial control:
+- **Their expertise carries weight** through accumulated vote power
+- **They guide through example** rather than mandate
+- **Community can override** through collective action
+- **Responsibility scales** with their increased influence
+
+## The Accountability Framework
+
+### Individual Accountability
+
+Every contributor is accountable for:
+- **Quality of their own contributions** (poor code affects their reputation)
+- **Voting decisions** (they help shape what gets merged)
+- **Project health** (they partially control its future)
+- **Community standards** (their behavior affects project culture)
+
+### Collective Accountability
+
+The contributor community is collectively responsible for:
+- **Project direction** through democratic voting
+- **Code quality** through review and approval processes
+- **Community standards** through peer accountability
+- **Long-term sustainability** through shared stewardship
+
+### Transparent Responsibility
+
+All responsibility is visible and auditable:
+- **Vote weights** are public and based on transparent contribution history
+- **Voting decisions** are recorded and attributed
+- **Contribution patterns** show who's building the project
+- **Influence calculations** are open for community verification
+
+## Responsibility in Action
+
+### Decision Making
+When reviewing pull requests, contributors must consider:
+- **Technical merit** of the proposed changes
+- **Project direction** alignment
+- **Long-term maintainability** implications
+- **Community impact** of their voting decision
+
+Their vote carries weight proportional to their investment, creating natural incentives for thoughtful decisions.
+
+### Quality Control
+Contributors become invested in maintaining high standards because:
+- **Poor quality** affects a project they help control
+- **Technical debt** becomes their problem to solve
+- **Security issues** impact their reputation and the project's future
+- **Community conflicts** disrupt something they've helped build
+
+### Conflict Resolution
+Disputes get resolved democratically rather than by maintainer decree:
+- **Controversial changes** require broader consensus
+- **Community disagreements** get decided by those who contribute
+- **Project direction changes** need support from active contributors
+- **Personal conflicts** can't override democratic process
+
+## The Investment Psychology
+
+### From Consumer to Owner Mindset
+
+Traditional open source creates consumer mentality:
+- "Someone else maintains this"
+- "I'll request features and wait"
+- "If I don't like it, I'll fork"
+
+Worlddriven creates owner mentality:
+- "I help control this project's future"
+- "My votes determine what gets built"
+- "I'm responsible for making this work"
+
+### Skin in the Game
+
+When you have voting power, you have skin in the game:
+- **Bad decisions** affect something you partially control
+- **Good contributions** improve your own project
+- **Quality issues** become your responsibility to fix
+- **Project success** directly benefits your work
+
+## Preventing Abuse
+
+### Democratic Safeguards
+
+Multiple mechanisms prevent individual abuse:
+- **Contribution history** determines vote weight (can't buy influence)
+- **Transparent calculations** prevent hidden manipulation
+- **Collective decisions** prevent individual control
+- **Historical accountability** creates reputation incentives
+
+### Community Self-Policing
+
+Responsible contributors naturally police bad actors:
+- **Poor contributors** get downvoted by quality contributors
+- **Malicious actors** face community resistance
+- **Spam submissions** get blocked by invested reviewers
+- **Disruptive behavior** threatens something contributors control
+
+### Gradual Influence Building
+
+New contributors must earn influence over time:
+- **First contribution** grants minimal voting power
+- **Sustained quality** work increases influence
+- **Community trust** develops through demonstrated responsibility
+- **Leadership roles** emerge naturally through merit
+
+## Benefits of the Responsibility Model
+
+### Sustainable Participation
+Contributors stay engaged because they control outcomes, not just hope for acceptance.
+
+### Higher Quality Standards
+People who control the project maintain higher standards because poor quality affects them directly.
+
+### Reduced Maintainer Burden
+Responsibility distributes across all contributors rather than concentrating on single maintainers.
+
+### Long-term Thinking
+Owners think long-term because they'll live with the consequences of decisions.
+
+### Community Investment
+Contributors become invested in project success, community health, and collaborative relationships.
+
+## Getting Started with Responsibility
+
+### For New Contributors
+1. **Make your first contribution** to gain voting rights
+2. **Participate in reviews** to exercise your democratic voice
+3. **Think like an owner** when evaluating changes
+4. **Build your influence** through sustained quality contributions
+
+### For Existing Projects
+1. **Enable worlddriven** to distribute decision-making power
+2. **Educate contributors** about their new responsibilities
+3. **Trust the democratic process** even when individual decisions differ from your preferences
+4. **Focus on influence through contribution** rather than maintainer authority
+
+## The Result: True Collaborative Ownership
+
+Worlddriven creates software projects that are genuinely owned and controlled by the people who build them. This aligns incentives, distributes responsibility, and creates sustainable communities where contributors are stakeholders, not supplicants.
+
+**Ready to take responsibility for the software you help create?**


### PR DESCRIPTION
Add complete documentation covering the vision and philosophy of worlddriven as democratic governance for open source software.

Includes:
- Main README with opening statement and responsibility theme
- RESPONSIBILITY.md explaining contributor power and accountability
- EXAMPLES.md with real-world governance failure case studies
- PHILOSOPHY.md covering democratic software development principles
- LICENSE file with AGPL-3.0-or-later for community protection

I think this describes relative good the idea of worlddriven, surely there can be a bit more polishing, but reads good IMHO.