### PR TITLE
feat: add organization repository management and drift detection

### DIFF
--- a/.github/workflows/drift-detection.yml
+++ b/.github/workflows/drift-detection.yml
@@ -1,0 +1,85 @@
+name: Repository Drift Detection
+
+on:
+  pull_request:
+    paths:
+      - 'REPOSITORIES.md'
+      - 'scripts/**'
+      - '.github/workflows/drift-detection.yml'
+
+jobs:
+  detect-drift:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+      contents: read
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Make scripts executable
+        run: chmod +x scripts/*.js
+
+      - name: Run drift detection
+        id: drift
+        env:
+          WORLDDRIVEN_GITHUB_TOKEN: ${{ secrets.WORLDDRIVEN_GITHUB_TOKEN }}
+        run: |
+          set +e
+          node scripts/detect-drift.js > drift-report.md 2>&1
+          EXIT_CODE=$?
+          echo "exit_code=$EXIT_CODE" >> $GITHUB_OUTPUT
+          set -e
+        continue-on-error: true
+
+      - name: Comment PR with drift report
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            const report = fs.readFileSync('drift-report.md', 'utf8');
+
+            // Find existing comment
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+            });
+
+            const botComment = comments.find(comment =>
+              comment.user.type === 'Bot' &&
+              comment.body.includes('Repository Drift Report')
+            );
+
+            const commentBody = `${report}\n\n---\n*🤖 This report is automatically generated on every PR that modifies REPOSITORIES.md*`;
+
+            if (botComment) {
+              // Update existing comment
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: botComment.id,
+                body: commentBody,
+              });
+            } else {
+              // Create new comment
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body: commentBody,
+              });
+            }
+
+      - name: Check drift detection result
+        if: steps.drift.outputs.exit_code != '0'
+        run: |
+          echo "⚠️ Drift detected between REPOSITORIES.md and GitHub organization"
+          echo "Review the drift report in the PR comment above"
+          exit 0

--- a/REPOSITORIES.md
+++ b/REPOSITORIES.md
@@ -1,0 +1,37 @@
+# Worlddriven Organization Repositories
+
+This file serves as the source of truth for all repositories in the worlddriven GitHub organization. Changes to this file via pull requests will automatically sync the organization structure through democratic voting.
+
+## Format
+
+Each repository is defined using markdown headers and properties:
+
+```markdown
+## repository-name
+- Description: Brief description of the repository
+- Topics: topic1, topic2, topic3
+```
+
+### Properties
+
+- **Repository Name**: Markdown heading level 2 (`##`)
+- **Description** (required): Brief description of the repository's purpose
+- **Topics** (optional): Comma-separated list of repository topics for discoverability
+
+## Example
+
+```markdown
+## worlddriven-core
+- Description: Democratic governance system for GitHub pull requests
+- Topics: democracy, open-source, governance, automation
+
+## worlddriven-documentation
+- Description: Vision, philosophy, and organization management for worlddriven
+- Topics: documentation, organization-management, governance
+```
+
+---
+
+## Current Repositories
+
+<!-- Add repositories below this line -->

--- a/package.json
+++ b/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "worlddriven-documentation",
+  "version": "1.0.0",
+  "description": "Vision, philosophy, and organization management for worlddriven",
+  "type": "module",
+  "scripts": {
+    "parse": "node scripts/parse-repositories.js",
+    "fetch-github": "node scripts/fetch-github-state.js",
+    "detect-drift": "node scripts/detect-drift.js"
+  },
+  "keywords": [
+    "worlddriven",
+    "documentation",
+    "organization-management",
+    "governance"
+  ],
+  "author": "worlddriven",
+  "license": "AGPL-3.0"
+}

--- a/scripts/detect-drift.js
+++ b/scripts/detect-drift.js
@@ -1,0 +1,194 @@
+#!/usr/bin/env node
+
+/**
+ * Detect drift between REPOSITORIES.md and actual GitHub organization state
+ * Compares desired state (REPOSITORIES.md) with actual state (GitHub API)
+ */
+
+import { parseRepositoriesFile } from './parse-repositories.js';
+import { fetchGitHubRepositories } from './fetch-github-state.js';
+
+/**
+ * Compare two arrays of topics
+ */
+function arraysEqual(a, b) {
+  if (!a && !b) return true;
+  if (!a || !b) return false;
+  if (a.length !== b.length) return false;
+  const sortedA = [...a].sort();
+  const sortedB = [...b].sort();
+  return sortedA.every((val, idx) => val === sortedB[idx]);
+}
+
+/**
+ * Detect differences between desired and actual repository states
+ */
+function detectDrift(desiredRepos, actualRepos) {
+  const drift = {
+    missing: [],        // In REPOSITORIES.md but not in GitHub
+    extra: [],          // In GitHub but not in REPOSITORIES.md
+    descriptionDiff: [], // Description mismatch
+    topicsDiff: [],     // Topics mismatch
+  };
+
+  // Create lookup maps
+  const desiredMap = new Map(desiredRepos.map(r => [r.name, r]));
+  const actualMap = new Map(actualRepos.map(r => [r.name, r]));
+
+  // Find missing and different repos
+  for (const desired of desiredRepos) {
+    const actual = actualMap.get(desired.name);
+
+    if (!actual) {
+      drift.missing.push(desired);
+    } else {
+      // Check description
+      if (desired.description !== actual.description) {
+        drift.descriptionDiff.push({
+          name: desired.name,
+          desired: desired.description,
+          actual: actual.description,
+        });
+      }
+
+      // Check topics
+      if (!arraysEqual(desired.topics, actual.topics)) {
+        drift.topicsDiff.push({
+          name: desired.name,
+          desired: desired.topics || [],
+          actual: actual.topics || [],
+        });
+      }
+    }
+  }
+
+  // Find extra repos
+  for (const actual of actualRepos) {
+    if (!desiredMap.has(actual.name)) {
+      drift.extra.push(actual);
+    }
+  }
+
+  return drift;
+}
+
+/**
+ * Format drift report as markdown
+ */
+function formatDriftReport(drift, desiredCount, actualCount) {
+  const lines = [];
+
+  lines.push('# 🔍 Repository Drift Report');
+  lines.push('');
+  lines.push(`**Summary**: ${desiredCount} repositories in REPOSITORIES.md, ${actualCount} repositories in GitHub organization`);
+  lines.push('');
+
+  const hasDrift = drift.missing.length > 0 ||
+                   drift.extra.length > 0 ||
+                   drift.descriptionDiff.length > 0 ||
+                   drift.topicsDiff.length > 0;
+
+  if (!hasDrift) {
+    lines.push('✅ **No drift detected** - REPOSITORIES.md matches GitHub organization state');
+    return lines.join('\n');
+  }
+
+  lines.push('⚠️ **Drift detected** - Differences found between REPOSITORIES.md and GitHub');
+  lines.push('');
+
+  // Missing repositories
+  if (drift.missing.length > 0) {
+    lines.push(`## 📝 Missing in GitHub (${drift.missing.length})`);
+    lines.push('');
+    lines.push('These repositories are defined in REPOSITORIES.md but do not exist in GitHub:');
+    lines.push('');
+    for (const repo of drift.missing) {
+      lines.push(`- **${repo.name}**: ${repo.description}`);
+    }
+    lines.push('');
+  }
+
+  // Extra repositories
+  if (drift.extra.length > 0) {
+    lines.push(`## ➕ Not in REPOSITORIES.md (${drift.extra.length})`);
+    lines.push('');
+    lines.push('These repositories exist in GitHub but are not documented in REPOSITORIES.md:');
+    lines.push('');
+    for (const repo of drift.extra) {
+      lines.push(`- **${repo.name}**: ${repo.description || '(no description)'}`);
+    }
+    lines.push('');
+  }
+
+  // Description differences
+  if (drift.descriptionDiff.length > 0) {
+    lines.push(`## 📄 Description Mismatches (${drift.descriptionDiff.length})`);
+    lines.push('');
+    for (const diff of drift.descriptionDiff) {
+      lines.push(`### ${diff.name}`);
+      lines.push(`- **In REPOSITORIES.md**: ${diff.desired || '(empty)'}`);
+      lines.push(`- **In GitHub**: ${diff.actual || '(empty)'}`);
+      lines.push('');
+    }
+  }
+
+  // Topics differences
+  if (drift.topicsDiff.length > 0) {
+    lines.push(`## 🏷️ Topics Mismatches (${drift.topicsDiff.length})`);
+    lines.push('');
+    for (const diff of drift.topicsDiff) {
+      lines.push(`### ${diff.name}`);
+      lines.push(`- **In REPOSITORIES.md**: ${diff.desired.join(', ') || '(none)'}`);
+      lines.push(`- **In GitHub**: ${diff.actual.join(', ') || '(none)'}`);
+      lines.push('');
+    }
+  }
+
+  return lines.join('\n');
+}
+
+/**
+ * Main function
+ */
+async function main() {
+  const token = process.env.WORLDDRIVEN_GITHUB_TOKEN;
+
+  if (!token) {
+    console.error('❌ Error: WORLDDRIVEN_GITHUB_TOKEN environment variable is not set');
+    process.exit(1);
+  }
+
+  try {
+    console.error('📖 Parsing REPOSITORIES.md...');
+    const desiredRepos = await parseRepositoriesFile();
+
+    console.error('🌐 Fetching GitHub organization state...');
+    const actualRepos = await fetchGitHubRepositories(token);
+
+    console.error('🔍 Detecting drift...\n');
+
+    const drift = detectDrift(desiredRepos, actualRepos);
+    const report = formatDriftReport(drift, desiredRepos.length, actualRepos.length);
+
+    console.log(report);
+
+    // Exit with error code if drift detected (useful for CI)
+    const hasDrift = drift.missing.length > 0 ||
+                     drift.extra.length > 0 ||
+                     drift.descriptionDiff.length > 0 ||
+                     drift.topicsDiff.length > 0;
+
+    process.exit(hasDrift ? 1 : 0);
+  } catch (error) {
+    console.error(`❌ Error: ${error.message}`);
+    process.exit(1);
+  }
+}
+
+// Export for use as module
+export { detectDrift, formatDriftReport };
+
+// CLI usage
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main();
+}

--- a/scripts/fetch-github-state.js
+++ b/scripts/fetch-github-state.js
@@ -1,0 +1,104 @@
+#!/usr/bin/env node
+
+/**
+ * Fetch current state of GitHub organization repositories
+ * Uses native fetch API to query GitHub
+ */
+
+const GITHUB_API_BASE = 'https://api.github.com';
+const ORG_NAME = 'worlddriven';
+
+/**
+ * Fetch all repositories for an organization
+ * @param {string} token - GitHub token from WORLDDRIVEN_GITHUB_TOKEN
+ * @returns {Promise<Array<{name: string, description: string, topics?: string[]}>>}
+ */
+async function fetchGitHubRepositories(token) {
+  if (!token) {
+    throw new Error('WORLDDRIVEN_GITHUB_TOKEN environment variable is required');
+  }
+
+  const repositories = [];
+  let page = 1;
+  const perPage = 100;
+
+  while (true) {
+    const url = `${GITHUB_API_BASE}/orgs/${ORG_NAME}/repos?per_page=${perPage}&page=${page}&type=all`;
+
+    const response = await fetch(url, {
+      headers: {
+        'Authorization': `Bearer ${token}`,
+        'Accept': 'application/vnd.github+json',
+        'X-GitHub-Api-Version': '2022-11-28',
+      },
+    });
+
+    if (!response.ok) {
+      const error = await response.text();
+      throw new Error(`GitHub API error (${response.status}): ${error}`);
+    }
+
+    const repos = await response.json();
+
+    if (repos.length === 0) {
+      break;
+    }
+
+    // Extract relevant information
+    for (const repo of repos) {
+      const repoData = {
+        name: repo.name,
+        description: repo.description || '',
+      };
+
+      // Fetch topics if available (requires special accept header)
+      if (repo.topics && repo.topics.length > 0) {
+        repoData.topics = repo.topics;
+      }
+
+      repositories.push(repoData);
+    }
+
+    // Check if there are more pages
+    if (repos.length < perPage) {
+      break;
+    }
+
+    page++;
+  }
+
+  return repositories.sort((a, b) => a.name.localeCompare(b.name));
+}
+
+/**
+ * Main function for CLI usage
+ */
+async function main() {
+  const token = process.env.WORLDDRIVEN_GITHUB_TOKEN;
+
+  if (!token) {
+    console.error('❌ Error: WORLDDRIVEN_GITHUB_TOKEN environment variable is not set');
+    console.error('');
+    console.error('Please set the token:');
+    console.error('  export WORLDDRIVEN_GITHUB_TOKEN=your_token_here');
+    process.exit(1);
+  }
+
+  try {
+    console.error(`Fetching repositories for organization: ${ORG_NAME}...`);
+    const repos = await fetchGitHubRepositories(token);
+    console.error(`✅ Found ${repos.length} repositories\n`);
+    console.log(JSON.stringify(repos, null, 2));
+  } catch (error) {
+    console.error(`❌ Error: ${error.message}`);
+    process.exit(1);
+  }
+}
+
+// Export for use as module
+export { fetchGitHubRepositories };
+
+// CLI usage
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main();
+}

--- a/scripts/parse-repositories.js
+++ b/scripts/parse-repositories.js
@@ -1,0 +1,107 @@
+#!/usr/bin/env node
+
+/**
+ * Parse REPOSITORIES.md and extract repository definitions
+ * Returns an array of repository objects
+ */
+
+import { readFile } from 'fs/promises';
+import { fileURLToPath } from 'url';
+import { dirname, join } from 'path';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+/**
+ * Parse markdown content and extract repository definitions
+ * @param {string} content - Markdown content
+ * @returns {Array<{name: string, description: string, topics?: string[]}>}
+ */
+function parseRepositories(content) {
+  const repositories = [];
+  const lines = content.split('\n');
+
+  let currentRepo = null;
+
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i].trim();
+
+    // Repository name (## heading)
+    if (line.startsWith('## ')) {
+      // Save previous repo if exists
+      if (currentRepo) {
+        repositories.push(currentRepo);
+      }
+
+      // Start new repo
+      const name = line.substring(3).trim();
+      // Skip example headings or special sections
+      if (name && !name.toLowerCase().includes('example') &&
+          !name.toLowerCase().includes('current repositories') &&
+          !name.toLowerCase().includes('format')) {
+        currentRepo = { name };
+      } else {
+        currentRepo = null;
+      }
+    }
+    // Properties (- Key: Value)
+    else if (currentRepo && line.startsWith('- ')) {
+      const propertyMatch = line.match(/^- ([^:]+):\s*(.+)$/);
+      if (propertyMatch) {
+        const [, key, value] = propertyMatch;
+        const keyLower = key.trim().toLowerCase();
+
+        if (keyLower === 'description') {
+          currentRepo.description = value.trim();
+        } else if (keyLower === 'topics') {
+          currentRepo.topics = value.split(',').map(t => t.trim()).filter(Boolean);
+        }
+      }
+    }
+  }
+
+  // Add last repo if exists
+  if (currentRepo) {
+    repositories.push(currentRepo);
+  }
+
+  // Validate repositories
+  const validated = repositories.filter(repo => {
+    if (!repo.name) {
+      console.warn('⚠️  Skipping repository without name');
+      return false;
+    }
+    if (!repo.description) {
+      console.warn(`⚠️  Repository "${repo.name}" is missing required description`);
+      return false;
+    }
+    return true;
+  });
+
+  return validated;
+}
+
+/**
+ * Read and parse REPOSITORIES.md file
+ * @returns {Promise<Array>}
+ */
+async function parseRepositoriesFile() {
+  const repoFilePath = join(__dirname, '..', 'REPOSITORIES.md');
+
+  try {
+    const content = await readFile(repoFilePath, 'utf-8');
+    return parseRepositories(content);
+  } catch (error) {
+    console.error(`Error reading REPOSITORIES.md: ${error.message}`);
+    process.exit(1);
+  }
+}
+
+// Export for use as module
+export { parseRepositories, parseRepositoriesFile };
+
+// CLI usage
+if (import.meta.url === `file://${process.argv[1]}`) {
+  const repos = await parseRepositoriesFile();
+  console.log(JSON.stringify(repos, null, 2));
+}


### PR DESCRIPTION
Implement infrastructure-as-code for worlddriven organization repositories:

- Add REPOSITORIES.md as single source of truth for repository definitions
- Create parse-repositories.js to extract repository data from markdown
- Create fetch-github-state.js using native fetch API for GitHub org state
- Create detect-drift.js to compare desired vs actual repository state
- Add GitHub Actions workflow for automated drift detection on PRs
- Configure package.json with ES modules support

The system currently provides drift detection - when a PR modifies REPOSITORIES.md, it will automatically comment with differences between the documented state and actual GitHub organization state.

This is Phase 1 of organization management via pull requests, embodying the worlddriven Phase 2 vision: transparent service management.