### PR TITLE
fix: make drift detection fail when transfer automation is not ready

### DIFF
--- a/scripts/detect-drift.js
+++ b/scripts/detect-drift.js
@@ -227,16 +227,17 @@ async function main() {
     console.log(report);
 
     // Exit with error code if drift detected (useful for CI)
-    // Note: pendingTransfer is informational, not an error
+    // Note: pendingTransfer blocks CI until transfer automation is implemented
     const hasDrift = drift.missing.length > 0 ||
                      drift.extra.length > 0 ||
                      drift.descriptionDiff.length > 0 ||
-                     drift.topicsDiff.length > 0;
+                     drift.topicsDiff.length > 0 ||
+                     drift.pendingTransfer.length > 0;
 
-    // Warn about pending transfers
+    // Warn about pending transfers (causes CI to fail)
     if (drift.pendingTransfer.length > 0) {
-      console.error('\n⚠️  Warning: Repository transfer feature is under development');
-      console.error('   PRs with Origin field will be blocked until transfer automation is complete');
+      console.error('\n❌ Error: Repository transfer feature is under development');
+      console.error('   This PR will be blocked until transfer automation is complete');
 
       // Check permission status
       const readyCount = drift.pendingTransfer.filter(


### PR DESCRIPTION
## Problem

Currently, the drift detection CI passes when repositories with `Origin` field are added to REPOSITORIES.md, even though:
- The repository doesn't exist in the org yet
- The transfer automation is not implemented
- The PR can't actually be executed successfully

This is misleading because the CI shows green but the PR represents actual drift that should block merging.

## Root Cause

In `scripts/detect-drift.js`, the `hasDrift` calculation excluded `pendingTransfer`:

```javascript
// Note: pendingTransfer is informational, not an error
const hasDrift = drift.missing.length > 0 ||
                 drift.extra.length > 0 ||
                 drift.descriptionDiff.length > 0 ||
                 drift.topicsDiff.length > 0;
// pendingTransfer was NOT included!
```

Repositories with `Origin` field were added to `drift.pendingTransfer` and then skipped all other checks (including the "missing" check), so they never caused the CI to fail.

## Solution

Update the drift detection logic to:
1. **Include `pendingTransfer` in `hasDrift` calculation** - Causes CI to fail when transfer automation is not ready
2. **Update messaging** - Change from warning (⚠️) to error (❌) to reflect blocking behavior
3. **Clarify comments** - Update code comments to reflect that pending transfers now block CI

## Changes

```javascript
// Exit with error code if drift detected (useful for CI)
// Note: pendingTransfer blocks CI until transfer automation is implemented
const hasDrift = drift.missing.length > 0 ||
                 drift.extra.length > 0 ||
                 drift.descriptionDiff.length > 0 ||
                 drift.topicsDiff.length > 0 ||
                 drift.pendingTransfer.length > 0;  // <-- Added

// Warn about pending transfers (causes CI to fail)
if (drift.pendingTransfer.length > 0) {
  console.error('\n❌ Error: Repository transfer feature is under development');  // ⚠️ -> ❌
  console.error('   This PR will be blocked until transfer automation is complete');
```

## Impact

After this fix:
- ✅ PRs with `Origin` field will **fail CI** until transfer automation is complete
- ✅ Clear error messaging explains why the PR is blocked
- ✅ Prevents misleading "green CI" when PRs can't actually be executed
- ✅ Aligns with existing documentation that says "PRs with Origin field will be blocked"

## Testing

This fix can be tested with PR #12 which adds a repository with `Origin` field:
- Before this fix: CI passes (incorrect)
- After this fix: CI should fail with clear error message (correct)

## Related

- Issue #9 - Repository transfer automation implementation
- PR #11 - Permission verification (partial implementation)
- PR #12 - First migration attempt (will demonstrate this fix)