### PR TITLE
fix: actually fail CI when transfer permissions are missing

### DIFF
--- a/.github/workflows/drift-detection.yml
+++ b/.github/workflows/drift-detection.yml
@@ -106,6 +106,7 @@ jobs:
       - name: Check drift detection result
         if: steps.drift.outputs.exit_code != '0'
         run: |
-          echo "⚠️ Drift detected between REPOSITORIES.md and GitHub organization"
-          echo "Review the drift report in the PR comment above"
-          exit 0
+          echo "❌ Transfer blocked: worlddriven lacks admin permission on source repository"
+          echo "Review the drift report in the workflow summary above"
+          echo "Grant worlddriven admin access to the source repository to unblock"
+          exit 1


### PR DESCRIPTION
## Summary

- Fixed workflow to actually fail when `detect-drift.js` exits with code 1
- PR #14 updated the script to exit 1 for blocked transfers, but the workflow still had `exit 0`
- Changed `exit 0` to `exit 1` in the final check step

## Root Cause

The workflow had:
```yaml
- name: Check drift detection result
  if: steps.drift.outputs.exit_code != '0'
  run: |
    echo "⚠️ Drift detected..."
    exit 0  # <-- BUG: should be exit 1
```

This meant the job always passed regardless of the script's exit code.
