### PR TITLE
feat: add worlddriven core repository for migration

### DIFF
--- a/REPOSITORIES.md
+++ b/REPOSITORIES.md
@@ -109,6 +109,11 @@ Track implementation progress in GitHub issue #9.
 
 <!-- Add repositories below this line -->
 
+## core
+- Description: Democratic governance system for GitHub pull requests
+- Topics: democracy, open-source, governance, automation, worlddriven
+- Origin: TooAngel/worlddriven
+
 ## documentation
 - Description: Core documentation repository for worlddriven project
 - Topics: documentation, worlddriven


### PR DESCRIPTION
## Summary

Add the worlddriven core repository to REPOSITORIES.md with Origin field
to initiate the migration from TooAngel/worlddriven to worlddriven/core.

This is the dogfooding test case for the repository transfer automation.

## Test plan

- [ ] Verify drift detection runs and shows permission status
- [ ] CI should fail until worlddriven has admin access to TooAngel/worlddriven