### PR TITLE
fix: add step-by-step instructions and direct URLs to drift report

### DIFF
--- a/scripts/detect-drift.js
+++ b/scripts/detect-drift.js
@@ -127,8 +127,14 @@ function formatDriftReport(drift, desiredCount, actualCount) {
           lines.push(`  - **Ready for transfer** (once transfer automation is complete)`);
         } else {
           lines.push(`  - ❌ **Permission Status**: ${permission.details}`);
-          lines.push(`  - **Action required**: Grant worlddriven admin access to ${repo.origin}`);
-          lines.push(`  - See REPOSITORIES.md for instructions on granting permissions`);
+          lines.push(`  - **Action required**: Grant worlddriven admin access to \`${repo.origin}\``);
+          lines.push('');
+          lines.push('  **How to grant access:**');
+          lines.push(`  1. Go to https://github.com/${repo.origin}/settings/access`);
+          lines.push('  2. Click "Add people" or "Add teams"');
+          lines.push('  3. Search for "worlddriven" and select the organization');
+          lines.push('  4. Set permission level to **Admin**');
+          lines.push('  5. Send the invitation - worlddriven will auto-accept');
         }
       } else {
         lines.push(`  - ⚠️ **Permission Status**: Not checked`);
@@ -258,7 +264,12 @@ async function main() {
     // Only fail CI if there are blocked transfers (missing permissions)
     if (blockedTransfers.length > 0) {
       console.error('\n❌ Error: Cannot proceed with repository transfer(s) - missing permissions');
-      console.error('   Grant worlddriven admin access to the source repositories to unblock');
+      console.error('');
+      for (const repo of blockedTransfers) {
+        console.error(`   → ${repo.origin}: https://github.com/${repo.origin}/settings/access`);
+      }
+      console.error('');
+      console.error('   Grant worlddriven "Admin" access at the URLs above to unblock this PR.');
       process.exit(1);
     }
 


### PR DESCRIPTION
## Summary

Improve the drift detection output to make it clearer how to grant admin permissions for repository transfers.

**Changes:**
- Add direct link to the repository's access settings page (e.g., `https://github.com/owner/repo/settings/access`)
- Include step-by-step instructions in the drift report
- Show clickable URLs in CI error output when transfers are blocked

**Before:**
```
- **Action required**: Grant worlddriven admin access to TooAngel/repo
- See REPOSITORIES.md for instructions on granting permissions
```

**After:**
```
- **Action required**: Grant worlddriven admin access to `TooAngel/repo`

  **How to grant access:**
  1. Go to https://github.com/TooAngel/repo/settings/access
  2. Click "Add people" or "Add teams"
  3. Search for "worlddriven" and select the organization
  4. Set permission level to **Admin**
  5. Send the invitation - worlddriven will auto-accept
```

## Test plan

- [ ] Create a PR with a repository transfer (PR #17)
- [ ] Verify the drift detection shows the new instructions
- [ ] Verify the CI error output includes the direct URL