### PR TITLE
revert: remove migration-test repository entry

### DIFF
--- a/REPOSITORIES.md
+++ b/REPOSITORIES.md
@@ -116,8 +116,3 @@ Track implementation progress in GitHub issue #9.
 ## webapp
 - Description: Web application interface for worlddriven
 - Topics: webapp, web, frontend, worlddriven
-
-## migration-test
-- Description: Test repository for worlddriven migration automation
-- Topics: test, migration, worlddriven
-- Origin: TooAngel/worlddriven-migration-test


### PR DESCRIPTION
## Summary

- Revert PR #27 which added `worlddriven-migration-test` to REPOSITORIES.md
- PR #27 was merged with the drift-detection check disabled, but the check was failing because fork PRs can't access the secrets needed for the migrate app permission check
- The migration-test entry can be re-added once the workflow and permissions are properly set up

## Context

The drift-detection CI was failing because:
1. `MIGRATE_APP_ID` and `MIGRATE_APP_PRIVATE_KEY` secrets were empty (fork PR + `pull_request` trigger)
2. The fallback token check also lacked admin access to the source repo